### PR TITLE
Added deploy.js as a binary

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * This script allows you to deploy a smart contract to an ethereum-based blockchain of
  * your choosing. The only requirement is that you have an unlocked account on an

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doc.ai/nrn-brainstem",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "NRN and related smart contracts",
   "main": "README.md",
   "repository": "git@github.com:doc-ai/nrn-brainstem.git",
@@ -8,6 +8,9 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "./node_modules/.bin/mocha"
+  },
+  "bin": {
+      "nrn-brainstem-deploy": "./deploy.js"
   },
   "dependencies": {
     "async": "^2.6.0",


### PR DESCRIPTION
This means that deploy.js shows up as nrn-brainstem-deploy in its
dependents' node_modules/.bin directories.

This required us to add a shebang line in deploy.js, as well.